### PR TITLE
Support installing the mco agent on Windows nodes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@ class pe_mco_shell_agent (
 
   $base = $::kernel ? {
     'windows' => $libdir,
-    'default' => "${libdir}/mcollective",
+    default   => "${libdir}/mcollective",
   }
 
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,22 @@
 class pe_mco_shell_agent (
-  $libdir = '/opt/puppet/libexec/mcollective',
-) {
-  $base = "${libdir}/mcollective"
+  $libdir = $pe_mco_shell_agent::libdir,
+  $owner  = $pe_mco_shell_agent::owner,
+  $group  = $pe_mco_shell_agent::group,
+  $mode   = $pe_mco_shell_agent::mode,
+) inherits pe_mco_shell_agent::params {
+
+  $base = $::kernel ? {
+    'windows' => $libdir,
+    'default' => "${libdir}/mcollective",
+  }
 
   File {
-    ensure => present,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
-    notify => Anchor['mco_shell_notify'],
+    ensure             => present,
+    owner              => $owner,
+    group              => $group,
+    mode               => $mode,
+    source_permissions => 'ignore',
+    notify             => Anchor['mco_shell_notify'],
   }
 
   # This anchor conditionally notifies the pe-mcollective service, but only if

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,18 @@
+class pe_mco_shell_agent::params {
+
+  case $::kernel {
+    'windows' : {
+      $libdir = 'C:/ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective'
+      $owner  = undef
+      $group  = undef
+      $mode   = undef
+    }
+    default : {
+      $libdir = '/opt/puppet/libexec/mcollective'
+      $owner  = 'root'
+      $group  = '0'
+      $mode   = '0644'
+    }
+  }
+
+}


### PR DESCRIPTION
Prior to this, the mco agent could not be installed on Windows nodes because the file paths and file owner/group were specific to Linux. Attempting to classify a Windows node with the module's main class resulted in a catalog enforcement error.

This fixes that by choosing compatible File defaults based on $::kernel.
