### PR TITLE
Fixed an error referencing param variables

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,9 @@
 class pe_mco_shell_agent (
-  $libdir  = $pe_mco_shell_agent::libdir,
-  $owner   = $pe_mco_shell_agent::owner,
-  $group   = $pe_mco_shell_agent::group,
-  $mode    = $pe_mco_shell_agent::mode,
-  $service = $pe_mco_shell_agent::service,
+  $libdir  = $pe_mco_shell_agent::params::libdir,
+  $owner   = $pe_mco_shell_agent::params::owner,
+  $group   = $pe_mco_shell_agent::params::group,
+  $mode    = $pe_mco_shell_agent::params::mode,
+  $service = $pe_mco_shell_agent::params::service,
 ) inherits pe_mco_shell_agent::params {
   $base = "${libdir}/mcollective"
 


### PR DESCRIPTION
The class definition had parameters such as this:
  $libdir  = $pe_mco_shell_agent::libdir

Which, when using the class, would result in the following error:

  Error while evaluating a Function Call, default expression for $libdir
  tries to illegally access not yet evaluated $libdir

The class parameters should reference the variables from the params
class instead:

  $libdir  = $pe_mco_shell_agent::params::libdir

After fixing this, the error no longer presents itself.
